### PR TITLE
Add couplings option to Julia driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ julia --project=julia -e 'using Pkg; Pkg.instantiate()'
 Then run the DMRG driver as
 
 ```bash
-julia --project=julia julia/run_chain.jl -l 6 -d 100 -s 5 -b p -o results.jld2
+julia --project=julia julia/run_chain.jl -l 6 -d 100 -s 5 -b p -j 1.0 -o results.jld2
 ```
 
 The output energy and MPS are stored in JLD2 format.

--- a/julia/run_chain.jl
+++ b/julia/run_chain.jl
@@ -20,6 +20,10 @@ function parse_commandline()
             help = "boundary condition (p/o/s/sp)"
             arg_type = String
             default = "p"
+        "--couplings", "-j"
+            help = "comma-separated list of coupling coefficients"
+            arg_type = String
+            default = "1.0"
         "--out", "-o"
             help = "output JLD2 file"
             arg_type = String
@@ -34,9 +38,11 @@ function main()
     maxdim = args["maxdim"] === nothing ? args["d"] : args["maxdim"]
     sweeps = args["sweeps"] === nothing ? args["s"] : args["sweeps"]
     boundary = args["boundary"] === nothing ? args["b"] : args["boundary"]
+    couplings_str = args["couplings"] === nothing ? args["j"] : args["couplings"]
+    couplings = parse.(Float64, split(couplings_str, ","))
     out = args["out"] === nothing ? args["o"] : args["out"]
     run_dmrg(L=L, maxdim=maxdim, sweeps=sweeps,
-             boundary=boundary, out=out)
+             boundary=boundary, couplings=couplings, out=out)
 end
 
 main()

--- a/julia/src/dmrgdriver.jl
+++ b/julia/src/dmrgdriver.jl
@@ -8,9 +8,10 @@ using ..GoldenModel
 export run_dmrg
 
 function run_dmrg(;L::Int, maxdim::Int=100, cutoff::Float64=1e-8, sweeps::Int=5,
-                   boundary::String="p", out::String="dmrg.jld2")
+                   boundary::String="p", couplings::Vector{<:Real}=[1.0],
+                   out::String="dmrg.jld2")
     sites = GoldenModel.Golden(L)
-    ampo = GoldenModel.hamiltonian(sites; boundary=boundary)
+    ampo = GoldenModel.hamiltonian(sites; boundary=boundary, couplings=couplings)
     H = ampo
     psi0 = random_mps([s.s for s in sites.sites])
     sweepset = Sweeps(sweeps)


### PR DESCRIPTION
## Summary
- allow specifying couplings in the Julia DMRG driver
- expose `--couplings` CLI flag
- document the new flag in README

## Testing
- `julia --project=julia -e 'using Chain; println("loaded")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c596b628832b9ff8ca20ee8d1475