### PR TITLE
Add runnable generic anyon model

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,26 @@ julia --project=julia julia/run_chain.jl -l 6 -d 100 -s 5 -b p -j 1.0 -o results
 ```
 
 The output energy and MPS are stored in JLD2 format.
+
+### Generic categories
+
+The module `Model.jl` provides a minimal interface for defining fusion
+categories directly in Julia.  Users can specify the number of anyon
+types and a table of `F`-symbols to construct an `AnyonModel`:
+
+```julia
+using Chain.Model
+m = AnyonModel(2; fsymbols=myF, qdims=[1.0, phi])
+```
+
+The returned object stores the categorical data and is used to build
+operators directly from the `F`-symbols. The F-move operator `FF` is
+constructed from these symbols so that no hard-coded constants (like
+the golden ratio) are required. A convenience function
+`fibonacci_model()` returns the Fibonacci fusion category so the DMRG
+driver can be run without importing `GoldenModel`:
+
+```julia
+using Chain
+energy = run_dmrg(L=6, model=Model.fibonacci_model())
+```

--- a/julia/src/Chain.jl
+++ b/julia/src/Chain.jl
@@ -6,6 +6,7 @@ using JLD2
 using ArgParse
 
 include("Golden.jl")
+include("Model.jl")
 include("utils.jl")
 include("dmrgdriver.jl")
 using .DMRGDriver: run_dmrg

--- a/julia/src/Model.jl
+++ b/julia/src/Model.jl
@@ -1,0 +1,204 @@
+module Model
+
+using ITensors
+using ITensorMPS: AutoMPO, MPO
+import ITensors: op, space, OpName, SiteType, @SiteType_str
+
+struct Anyon end
+
+export AnyonModel, AnyonSite, AnyonChain, FSymbol, site, hamiltonian,
+       fibonacci_model
+
+"""
+    AnyonModel(rank; fsymbols, qdims)
+
+Create a generic fusion category model. `rank` is the number of simple
+anyons. `fsymbols` is a 6-index array `fsymbols[a,b,c,d,e,f]` giving the
+`F`-symbols and should have dimensions `(rank,rank,rank,rank,rank,rank)`.
+`qdims` is a vector of quantum dimensions of length `rank`.
+"""
+struct AnyonModel
+    rank::Int
+    fsymbols::Array{ComplexF64,6}
+    qdims::Vector{Float64}
+end
+
+const active_model = Ref{AnyonModel}()
+
+function AnyonModel(rank::Int; fsymbols=zeros(ComplexF64,rank,rank,rank,rank,rank,rank), qdims=ones(Float64,rank))
+    size(fsymbols) == (rank,rank,rank,rank,rank,rank) ||
+        error("fsymbols must have size (rank,rank,rank,rank,rank,rank)")
+    length(qdims) == rank || error("qdims must have length rank")
+    return AnyonModel(rank, ComplexF64.(fsymbols), Float64.(qdims))
+end
+
+"""Return the F-symbol F^{abc}_{def}."""
+FSymbol(model::AnyonModel, a,b,c,d,e,f) = model.fsymbols[a,b,c,d,e,f]
+
+"""Return an Index for site `n`."""
+site(model::AnyonModel, n::Integer) = Index(model.rank, "Anyon,Site,n=$n")
+
+"""
+    struct AnyonSite
+
+Represents a lattice site for a given `AnyonModel`.
+"""
+struct AnyonSite
+    model::AnyonModel
+    s::Index
+end
+
+space(::SiteType"Anyon"; kwargs...) = active_model[].rank
+
+function op(o::OpName, ::SiteType"Anyon"; kwargs...)
+    m = active_model[]
+    name = String(ITensors.name(o))
+    if name == "id"
+        return Matrix{Float64}(I, m.rank, m.rank)
+    elseif startswith(name, "n")
+        i = parse(Int, last(split(name, "n")))
+        M = zeros(Float64, m.rank, m.rank)
+        M[i,i] = 1.0
+        return M
+    elseif name == "FF"
+        F = zeros(ComplexF64, m.rank, m.rank)
+        ρ = m.rank
+        for i in 1:m.rank, j in 1:m.rank
+            F[i,j] = FSymbol(m, ρ, ρ, ρ, ρ, i, j)
+        end
+        return F
+    else
+        return nothing
+    end
+end
+
+AnyonSite(model::AnyonModel, n::Integer) =
+    AnyonSite(model, site(model, n))
+
+"""Projector onto anyon type `i`."""
+function proj(site::AnyonSite, i::Integer)
+    s = site.s
+    sp = prime(s)
+    op = ITensor(dag(s), sp)
+    op[s(i), sp(i)] = 1.0
+    return op
+end
+
+"""
+    FF(site::AnyonSite)
+
+Return the F-move operator associated with the `AnyonModel` of `site`.
+It is constructed entirely from the `F`-symbols stored in the model.
+
+Currently this assumes the nontrivial anyon is labelled `rank(model)`
+and the trivial anyon is `1`, which is appropriate for the golden
+chain.
+"""
+function FF(site::AnyonSite)
+    m = site.model
+    s = site.s
+    sp = prime(s)
+    ρ = m.rank
+    op = ITensor(dag(s), sp)
+    for i in 1:m.rank, j in 1:m.rank
+        op[s(i), sp(j)] = FSymbol(m, ρ, ρ, ρ, ρ, i, 1) *
+                          FSymbol(m, ρ, ρ, ρ, ρ, 1, j)
+    end
+    return op
+end
+
+function op(site::AnyonSite, name::String)
+    s = site.s
+    if name == "id"
+        return ITensor(delta(s, prime(s)))
+    elseif occursin("n", name)
+        i = parse(Int, last(split(name, "n")))
+        return proj(site, i)
+    elseif name == "FF"
+        return FF(site)
+    else
+        error("Operator $name not recognized")
+    end
+end
+
+struct AnyonChain{M<:AnyonModel} <: AbstractVector{AnyonSite}
+    model::M
+    sites::Vector{AnyonSite}
+end
+
+AnyonChain(model::AnyonModel, N::Int) = begin
+    active_model[] = model
+    AnyonChain(model, [AnyonSite(model, n) for n in 1:N])
+end
+
+Base.length(c::AnyonChain) = length(c.sites)
+Base.getindex(c::AnyonChain, i::Int) = c.sites[i]
+
+"""Generic three-body Hamiltonian used for the golden chain."""
+function hamiltonian(c::AnyonChain; boundary::String="p", couplings=[1.0])
+    L = length(c)
+    K = couplings[1]
+    ampo = AutoMPO()
+    Lproj = boundary == "p" ? L : L - 2
+    if boundary == "sp"
+        Lproj = L - 3
+    end
+    for j in 1:Lproj
+        jp1 = mod(j, L) + 1
+        jp2 = mod(j + 1, L) + 1
+        ampo += K, "n1", j, "n2", jp1, "n1", jp2
+        ampo += K, "n2", j, "FF", jp1, "n2", jp2
+    end
+    return MPO(ampo, [s.s for s in c.sites])
+end
+
+"""Return a predefined Fibonacci anyon model."""
+function fibonacci_model()
+    phi = (sqrt(5)+1)/2
+    phi_inv = 1/phi
+    sqrt_phi_inv = sqrt(phi_inv)
+    fs = Array{ComplexF64,6}(undef, 2,2,2,2,2,2)
+    dual(i) = i
+    isinv(i) = i == 1
+    function add(i,j)
+        2
+    end
+    function fusion(a,b)
+        if a == 1 && b == 1
+            return (1,)
+        elseif a == 1 && b == 2
+            return (2,)
+        elseif a == 2 && b == 1
+            return (2,)
+        else
+            return (1,2)
+        end
+    end
+    function hasfusion(i,j,k)
+        k in fusion(i,j)
+    end
+    function fsym(i,j,k,l,m,n)
+        if i == 2 && j == 2 && k == 2 && m == 2 && !isinv(l) && !isinv(n)
+            return -phi_inv
+        end
+        if !(hasfusion(i,j,m) && hasfusion(k,dual(l),dual(m)) &&
+              hasfusion(dual(l), i, dual(n)) && hasfusion(j,k,n))
+            return 0.0
+        end
+        if isinv(i) || isinv(j) || isinv(k) || isinv(l)
+            return 1.0
+        elseif isinv(m) && isinv(n)
+            return phi_inv
+        elseif isinv(m) || isinv(n)
+            return sqrt_phi_inv
+        else
+            return -phi_inv
+        end
+    end
+    for a in 1:2, b in 1:2, c in 1:2, d in 1:2, e in 1:2, f in 1:2
+        fs[a,b,c,d,e,f] = fsym(a,b,c,d,e,f)
+    end
+    AnyonModel(2; fsymbols=fs, qdims=[1.0, phi])
+end
+
+end # module

--- a/julia/src/dmrgdriver.jl
+++ b/julia/src/dmrgdriver.jl
@@ -3,15 +3,15 @@ module DMRGDriver
 using ITensors
 using ITensorMPS: random_mps, Sweeps, maxdim!, cutoff!, dmrg
 using JLD2
-using ..GoldenModel
+using ..Model
 
 export run_dmrg
 
 function run_dmrg(;L::Int, maxdim::Int=100, cutoff::Float64=1e-8, sweeps::Int=5,
-                   boundary::String="p", couplings::Vector{<:Real}=[1.0],
-                   out::String="dmrg.jld2")
-    sites = GoldenModel.Golden(L)
-    ampo = GoldenModel.hamiltonian(sites; boundary=boundary, couplings=couplings)
+                  boundary::String="p", couplings::Vector{<:Real}=[1.0],
+                  out::String="dmrg.jld2", model::AnyonModel=fibonacci_model())
+    sites = AnyonChain(model, L)
+    ampo = hamiltonian(sites; boundary=boundary, couplings=couplings)
     H = ampo
     psi0 = random_mps([s.s for s in sites.sites])
     sweepset = Sweeps(sweeps)


### PR DESCRIPTION
## Summary
- implement a simple site type for the generic anyon model
- register operators through `SiteType"Anyon"`
- activate the model when building an `AnyonChain`
- run length-3 DMRG with the new model

## Testing
- `julia --project=julia -e 'using Chain; using Chain.Model; run_dmrg(L=3, sweeps=1, maxdim=10, model=fibonacci_model())'`


------
https://chatgpt.com/codex/tasks/task_e_6869452b66dc832ba3db78e194f9d812