### PR TITLE
Allow selecting anyon model in Julia driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ Install the dependencies with Julia 1.x:
 julia --project=julia -e 'using Pkg; Pkg.instantiate()'
 ```
 
-Then run the DMRG driver as
+Then run the DMRG driver as. Use `-m haagerup` to run the Haagerup chain or omit
+the flag for the default golden chain.
 
 ```bash
-julia --project=julia julia/run_chain.jl -l 6 -d 100 -s 5 -b p -j 1.0 -u 2.0 -o results.jld2
+julia --project=julia julia/run_chain.jl -l 6 -d 100 -s 5 -b p -j 1.0 -u 2.0 -m haagerup -o results.jld2
 ```
 
 The output energy and MPS are stored in JLD2 format.

--- a/julia/run_chain.jl
+++ b/julia/run_chain.jl
@@ -1,5 +1,6 @@
 #!/usr/bin/env julia
 using Chain
+using Chain.Model
 using ArgParse
 
 function parse_commandline()
@@ -28,6 +29,10 @@ function parse_commandline()
             help = "penalty coefficient"
             arg_type = Float64
             default = 0.0
+        "--model", "-m"
+            help = "anyon model (golden/haagerup)"
+            arg_type = String
+            default = "golden"
         "--out", "-o"
             help = "output JLD2 file"
             arg_type = String
@@ -45,9 +50,12 @@ function main()
     couplings_str = args["couplings"] === nothing ? args["j"] : args["couplings"]
     couplings = parse.(Float64, split(couplings_str, ","))
     U = args["penalty"] === nothing ? args["u"] : args["penalty"]
+    modelname = args["model"] === nothing ? args["m"] : args["model"]
+    model = lowercase(modelname) == "haagerup" ? Model.haagerup_model() : Model.fibonacci_model()
     out = args["out"] === nothing ? args["o"] : args["out"]
     run_dmrg(L=L, maxdim=maxdim, sweeps=sweeps,
-             boundary=boundary, couplings=couplings, U=U, out=out)
+             boundary=boundary, couplings=couplings, U=U, out=out,
+             model=model)
 end
 
 main()


### PR DESCRIPTION
## Summary
- add `--model` argument to `julia/run_chain.jl`
- choose between golden and Haagerup models
- document the new option in the README

## Testing
- `julia --project=julia julia/run_chain.jl -l 2 -m haagerup -d 10 -s 1 -j 0,-1,0 -u 0 -o dummy.jld2`

------
https://chatgpt.com/codex/tasks/task_e_6869d116dd90832b99ed91b2b0e99d40