### PR TITLE
Fix missing LinearAlgebra import

### DIFF
--- a/julia/src/Model.jl
+++ b/julia/src/Model.jl
@@ -1,6 +1,7 @@
 module Model
 
 using ITensors
+using LinearAlgebra
 using ITensorMPS: AutoMPO, MPO
 import ITensors: op, space, OpName, SiteType, @SiteType_str
 


### PR DESCRIPTION
## Summary
- import `LinearAlgebra` in `Model.jl` so `I` is defined

## Testing
- `julia --project=julia -e 'using Chain.Model; Model.active_model[] = Model.fibonacci_model(); println(Model.op(Model.OpName("id"), Model.SiteType"Anyon"()))'` *(fails: Package ITensors is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869f6f166a0832b928209919053baa0