### PR TITLE
Fix op identity and update package info

### DIFF
--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,9 +1,10 @@
 name = "Chain"
 authors = ["Chain Migration"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 ITensorMPS = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/julia/src/Model.jl
+++ b/julia/src/Model.jl
@@ -1,6 +1,7 @@
 module Model
 
 using ITensors
+using LinearAlgebra
 using ITensorMPS: AutoMPO, MPO
 import ITensors: op, space, OpName, SiteType, @SiteType_str
 


### PR DESCRIPTION
## Summary
- bring in the LinearAlgebra standard library so the `I` constant is defined
- bump Chain version and record LinearAlgebra in `Project.toml`

## Testing
- `julia --project=julia -e 'using Chain.Model; Model.active_model[] = Model.fibonacci_model(); println(Model.op(Model.OpName("id"), Model.SiteType"Anyon"()))'` *(fails: Package ITensors is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869f6f166a0832b928209919053baa0