### PR TITLE
Add excited-state DMRG support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ julia --project=julia -e 'using Pkg; Pkg.instantiate()'
 ```
 
 Then run the DMRG driver as. Use `-m haagerup` to run the Haagerup chain or omit
-the flag for the default golden chain.
+the flag for the default golden chain. The option `-n` requests a number of
+excited states and `-w` sets the orthogonality weight used when targeting
+excited states.
 
 ```bash
 julia --project=julia julia/run_chain.jl -l 6 -d 100 -s 5 -b p -j 1.0 -u 2.0 -m haagerup -o results.jld2

--- a/julia/run_chain.jl
+++ b/julia/run_chain.jl
@@ -33,6 +33,14 @@ function parse_commandline()
             help = "anyon model (golden/haagerup)"
             arg_type = String
             default = "golden"
+        "--nstates", "-n"
+            help = "number of states to target"
+            arg_type = Int
+            default = 1
+        "--weight", "-w"
+            help = "orthogonality weight"
+            arg_type = Float64
+            default = 1000.0
         "--out", "-o"
             help = "output JLD2 file"
             arg_type = String
@@ -55,11 +63,14 @@ function main()
     U = args["penalty"] === nothing ? args["u"] : args["penalty"]
     modelname = args["model"] === nothing ? args["m"] : args["model"]
     model = lowercase(modelname) == "haagerup" ? Model.haagerup_model() : Model.fibonacci_model()
+    nstates = args["nstates"] === nothing ? args["n"] : args["nstates"]
+    weight = args["weight"] === nothing ? args["w"] : args["weight"]
     out = args["out"] === nothing ? args["o"] : args["out"]
     use_amdgpu = get(args, "amdgpu", false)
     run_dmrg(L=L, maxdim=maxdim, sweeps=sweeps,
              boundary=boundary, couplings=couplings, U=U, out=out,
-             model=model, amdgpu=use_amdgpu)
+             model=model, amdgpu=use_amdgpu,
+             nstates=nstates, weight=weight)
 end
 
 main()

--- a/julia/src/dmrgdriver.jl
+++ b/julia/src/dmrgdriver.jl
@@ -13,24 +13,38 @@ function run_dmrg(;L::Int, maxdim::Int=100, cutoff::Float64=1e-8, sweeps::Int=5,
                   boundary::String="p", U::Real=0.0,
                   couplings::Vector{<:Real}=[1.0],
                   out::String="dmrg.jld2", model::AnyonModel=fibonacci_model(),
-                  amdgpu::Bool=false)
+                  amdgpu::Bool=false, nstates::Int=1,
+                  weight::Float64=1000.0)
     sites = AnyonChain(model, L)
     ampo = hamiltonian(sites; boundary=boundary, U=U, couplings=couplings)
     H = ampo
-    psi0 = random_mps([s.s for s in sites.sites])
     if amdgpu
         H = AMDGPU.roc(H)
-        psi0 = AMDGPU.roc(psi0)
     end
     sweepset = Sweeps(sweeps)
     maxdim!(sweepset, maxdim)
     cutoff!(sweepset, cutoff)
-    energy, psi = dmrg(H, psi0, sweepset; outputlevel=0)
-    if amdgpu
-        psi = Adapt.adapt(Array, psi)
+
+    psis = MPS[]
+    energies = Float64[]
+    for n in 1:nstates
+        psi0 = random_mps([s.s for s in sites.sites])
+        if amdgpu
+            psi0 = AMDGPU.roc(psi0)
+        end
+        if n == 1
+            energy, psi = dmrg(H, psi0, sweepset; outputlevel=0)
+        else
+            energy, psi = dmrg(H, psis, psi0, sweepset; weight=weight, outputlevel=0)
+        end
+        if amdgpu
+            psi = Adapt.adapt(Array, psi)
+        end
+        push!(psis, psi)
+        push!(energies, energy)
     end
-    @save out energy psi
-    return energy
+    @save out energies psis
+    return energies
 end
 
 end


### PR DESCRIPTION
## Summary
- add `nstates` and `weight` options to CLI
- extend DMRG driver to find multiple excited states
- mention new options in README

## Testing
- `julia --project=julia -e 'using Pkg; Pkg.status();'`
- `julia --project=julia -e 'using Pkg; Pkg.resolve()'`
- `julia --project=julia -e 'using Pkg; Pkg.instantiate()'` *(fails: ROCm discovery failed)*

------
https://chatgpt.com/codex/tasks/task_e_686a40b771f0832b8684b4d98f4fa607